### PR TITLE
Put "See Rules" it its own paragraph

### DIFF
--- a/components/ClaimSpymasterOrSwitchTeam.tsx
+++ b/components/ClaimSpymasterOrSwitchTeam.tsx
@@ -85,6 +85,8 @@ const ClaimSpymaster = () => {
               }}
               spymaster gives a hint to start the game!
             </Trans>
+          </p>
+          <p className="text-center pt-4">
             <button
               className="underline hover:text-gray-700"
               onClick={() => setShowModal(true)}
@@ -101,6 +103,8 @@ const ClaimSpymaster = () => {
               "start-game-duet",
               "Click on a card or give a hint to start the game!"
             )}
+          </p>
+          <p className="text-center pt-4">
             <button
               className="underline hover:text-gray-700"
               onClick={() => setShowModal(true)}


### PR DESCRIPTION
There's no gap between the instructions and the "See rules" button (which renders like text - so it looks like there's a missing " " character). This change puts "See rules" in its own paragraph so it will appear separately, below the instructions.