### PR TITLE
Issue 24: points for one card in duet mode

### DIFF
--- a/lib/selectors.ts
+++ b/lib/selectors.ts
@@ -190,7 +190,7 @@ export const scoresSelector = createSelector(
       const grid = gridSelector({ playerId: "", game }) as IDuetGrid;
       return uniqBy(
         turns,
-        (t) => t.type === "click" && `${t.from}${t.value}`
+        (t) => t.type === "click" && `${players[t.from].team}${t.value}`
       ).reduce(
         (acc, turn) => {
           if (turn.type === "click") {


### PR DESCRIPTION
This is to not give 2 points for one card when two people from the same side click on the card at the same time. Isssue #24 

It wont stop giving two points for a Green-Green card if different sides click the card at the same time, however that is a rarer issue, and should also be handled by Issue #38 

Also, thank you for making this product, I play this weekly with some of my friends who I dont get to see in person anymore